### PR TITLE
Add platform/sdk

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -74,6 +74,7 @@
   <project path="ndk" name="platform/ndk" />
   <project path="prebuilt" name="platform/prebuilt" />
   <project path="rilproxy" name="rilproxy" remote="b2g" />
+  <project path="sdk" name="platform/sdk" />
   <project path="system/bluetooth" name="platform/system/bluetooth" />
   <project path="system/core" name="platform/system/core" />
   <project path="system/extras" name="platform/system/extras" />


### PR DESCRIPTION
Commit 80d4ba77 in development.git moved emulator GLES to sdk.git. This change
should fix build failure of missing render_api.h

Change-Id: I20585fc1b98e676235f0d092cbac6b7858a9f602
Signed-off-by: Vicamo Yang vyang@mozilla.com
