### PR TITLE
In china, can't connect https://android.googlesource.com/ in anonymous.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -2,7 +2,7 @@
 <manifest>
 
   <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
+           fetch="https://android.googlesource.com/a/" />
   <remote name="b2g"
           fetch="git://github.com/mozilla-b2g/" />
   <default revision="master"


### PR DESCRIPTION
use authenticated path.
Using authentication
By default, access to the Android source code is anonymous. To protect the servers against excessive usage, each IP address is associated with a quota.

When sharing an IP address with other users (e.g. when accessing the source repositories from beyond a NAT firewall), the quotas can trigger even for regular usage patterns (e.g. if many users sync new clients from the same IP address within a short period).

In that case, it is possible to use authenticated access, which then uses a separate quota for each user, regardless of the IP address.

The first step is to create a password from the password generator and to save it in ~/.netrc according to the instructions on that page.

The second step is to force authenticated access, by using the following manifest URI: https://android.googlesource.com/a/platform/manifest. Notice how the /a/ directory prefix triggers mandatory authentication. You can convert an existing client to use mandatory authentication with the following command:

$ repo init -u https://android.googlesource.com/a/platform/manifest
